### PR TITLE
Fix race condition when multiple sub-agents report back simultaneously

### DIFF
--- a/packages/claude_api/lib/src/client/claude_client.dart
+++ b/packages/claude_api/lib/src/client/claude_client.dart
@@ -377,6 +377,10 @@ class ClaudeClientImpl implements ClaudeClient {
 
                       _updateConversation(updatedConversation);
 
+                      // Clear active process BEFORE notifying turn complete
+                      // so that inbox processing can start the next message
+                      _activeProcess = null;
+
                       // Notify listeners that the turn is complete
                       _turnCompleteController.add(null);
                     } else if (response is ErrorResponse) {
@@ -396,6 +400,10 @@ class ClaudeClientImpl implements ClaudeClient {
                       } else {
                         _updateConversation(_currentConversation.addMessage(errorMessage).withError(response.error));
                       }
+
+                      // Clear process and notify on error too
+                      _activeProcess = null;
+                      _turnCompleteController.add(null);
                     } else {
                       // For any other response type (MetaResponse, StatusResponse, etc.)
                       // Just accumulate it but don't update UI yet


### PR DESCRIPTION
## Summary
- Fixes bug where messages from sub-agents could be lost when multiple agents report back at nearly the same time
- Adds an inbox architecture to `ClaudeClient` that queues messages when a process is active
- Processes queued messages in FIFO order via the existing `onTurnComplete` stream

## Problem
When a main agent spawns multiple sub-agents for research, and those sub-agents complete at nearly the same time, the main agent could miss messages. This happened because `sendMessage()` would immediately start a new Claude process without checking if one was already running, causing process references to be overwritten and messages to be lost.

## Solution
- Added `_inbox` list to queue messages when `_activeProcess` is non-null
- Added `_inboxSubscription` that listens to `onTurnComplete` to process the inbox
- Messages are now processed in order when the current turn completes
- Cleaned up subscription on `close()`

## Test plan
- [ ] Spawn multiple sub-agents in parallel that report back quickly
- [ ] Verify all messages are received by the main agent
- [ ] Verify messages are processed in order (FIFO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)