### PR TITLE
feat: Add Haiku-powered dynamic placeholder text

### DIFF
--- a/lib/modules/haiku/prompts/placeholder_prompt.dart
+++ b/lib/modules/haiku/prompts/placeholder_prompt.dart
@@ -1,0 +1,23 @@
+/// Prompt builder for dynamic input field placeholder text
+class PlaceholderPrompt {
+  static String build(DateTime now) {
+    final randomSeed = now.millisecondsSinceEpoch % 100;
+
+    return '''
+Generate witty placeholder text for an AI coding assistant input field.
+
+Seed: $randomSeed
+
+RULES:
+- 3-5 words only
+- Playful, slightly cheeky tone
+- Like a friend asking what you want to work on
+- BANNED: "What's on your mind", "Describe your", "Enter your", "Type here"
+- Be creative! Think: "What are we breaking today?", "Got bugs?", "Your wish, my code..."
+
+CRITICAL: Output ONLY the placeholder text itself.
+NO explanations, NO options, NO numbering, NO markdown.
+Just the 3-5 word phrase, nothing else.
+''';
+  }
+}


### PR DESCRIPTION
## Summary
Generates witty placeholder text using Claude Haiku at startup, with a typing animation effect.

**Stacked on PR #5** (`feature/haiku-core-clean`)

## What's Included

### New Files
- `lib/modules/haiku/prompts/placeholder_prompt.dart` - Prompt for generating creative placeholders

### Modified Files
- `lib/modules/agent_network/pages/networks_overview_page.dart` - Haiku integration + typing animation

## User-Visible Behavior
1. On startup, Haiku generates a witty 3-5 word placeholder
2. Text appears with typing animation effect
3. Falls back to static text if Haiku fails
4. Examples: "What are we breaking today?", "Got bugs?", "Your wish, my code..."

## Test Plan
- [ ] Launch app, verify placeholder appears with typing animation
- [ ] Verify fallback works when Haiku unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)