### PR TITLE
Remove cost indicator from TUI

### DIFF
--- a/lib/modules/agent_network/network_execution_page.dart
+++ b/lib/modules/agent_network/network_execution_page.dart
@@ -393,17 +393,6 @@ class _AgentChatState extends State<_AgentChat> {
               ),
             ),
           ],
-
-          // Cost display
-          if (_conversation.totalCostUsd > 0) ...[
-            Expanded(child: SizedBox()),
-            Text(
-              '\$${_conversation.totalCostUsd.toStringAsFixed(4)}',
-              style: TextStyle(
-                color: theme.base.onSurface.withOpacity(TextOpacity.tertiary),
-              ),
-            ),
-          ],
         ],
       ),
     );


### PR DESCRIPTION
Remove the cost display (showing USD amount) from the context usage
bar in the network execution page.