### PR TITLE
feat: add Ctrl+O shortcut to toggle thinking token display

### DIFF
--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -23,3 +23,19 @@ void setTheme(ProviderContainer container, String? themeId) {
   configManager.setTheme(themeId);
   container.read(themeSettingProvider.notifier).state = themeId;
 }
+
+/// Provider for controlling whether thinking tokens are displayed.
+/// Toggle with Ctrl+O shortcut.
+final showThinkingProvider = StateProvider<bool>((ref) {
+  final configManager = ref.read(videConfigManagerProvider);
+  return configManager.getShowThinking();
+});
+
+/// Toggles the showThinking setting and persists it to config.
+void toggleShowThinking(ProviderContainer container) {
+  final configManager = container.read(videConfigManagerProvider);
+  final current = container.read(showThinkingProvider);
+  final newValue = !current;
+  configManager.setShowThinking(newValue);
+  container.read(showThinkingProvider.notifier).state = newValue;
+}

--- a/packages/claude_sdk/lib/src/client/conversation_loader.dart
+++ b/packages/claude_sdk/lib/src/client/conversation_loader.dart
@@ -290,7 +290,20 @@ class ConversationLoader {
           if (block is Map<String, dynamic>) {
             final blockType = block['type'] as String?;
 
-            if (blockType == 'text') {
+            if (blockType == 'thinking') {
+              final thinking = block['thinking'] as String? ?? '';
+              if (thinking.isNotEmpty) {
+                responses.add(
+                  ThinkingResponse(
+                    id:
+                        block['id'] as String? ??
+                        DateTime.now().millisecondsSinceEpoch.toString(),
+                    timestamp: DateTime.now(),
+                    content: HtmlEntityDecoder.decode(thinking),
+                  ),
+                );
+              }
+            } else if (blockType == 'text') {
               final text = block['text'] as String? ?? '';
               if (text.isNotEmpty) {
                 responses.add(

--- a/packages/claude_sdk/lib/src/client/response_processor.dart
+++ b/packages/claude_sdk/lib/src/client/response_processor.dart
@@ -46,7 +46,7 @@ class ResponseProcessor {
       responses = [response];
     }
 
-    if (response is TextResponse) {
+    if (response is TextResponse || response is ThinkingResponse) {
       return _processTextResponse(
         response,
         currentConversation,
@@ -92,13 +92,14 @@ class ResponseProcessor {
   }
 
   ProcessResult _processTextResponse(
-    TextResponse response,
+    ClaudeResponse response,
     Conversation currentConversation,
     String assistantId,
     ConversationMessage? existingMessage,
     bool isAssistantMessage,
     List<ClaudeResponse> responses,
   ) {
+    // Works for both TextResponse and ThinkingResponse
     // Extract usage if available
     final usage = _extractUsageFromRawData(response.rawData);
 

--- a/packages/claude_sdk/lib/src/models/response.dart
+++ b/packages/claude_sdk/lib/src/models/response.dart
@@ -75,6 +75,30 @@ sealed class ClaudeResponse {
   }
 }
 
+/// Response containing thinking/reasoning content from extended thinking.
+@JsonSerializable()
+class ThinkingResponse extends ClaudeResponse {
+  final String content;
+
+  const ThinkingResponse({
+    required super.id,
+    required super.timestamp,
+    required this.content,
+    super.rawData,
+  });
+
+  factory ThinkingResponse.fromJson(Map<String, dynamic> json) {
+    return ThinkingResponse(
+      id: json['id'] ?? DateTime.now().millisecondsSinceEpoch.toString(),
+      timestamp: DateTime.now(),
+      content: json['thinking'] ?? json['content'] ?? json['text'] ?? '',
+      rawData: json,
+    );
+  }
+
+  Map<String, dynamic> toJson() => _$ThinkingResponseToJson(this);
+}
+
 @JsonSerializable()
 class TextResponse extends ClaudeResponse {
   final String content;

--- a/packages/claude_sdk/lib/src/models/response.g.dart
+++ b/packages/claude_sdk/lib/src/models/response.g.dart
@@ -6,6 +6,22 @@ part of 'response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+ThinkingResponse _$ThinkingResponseFromJson(Map<String, dynamic> json) =>
+    ThinkingResponse(
+      id: json['id'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      content: json['content'] as String,
+      rawData: json['rawData'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$ThinkingResponseToJson(ThinkingResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'timestamp': instance.timestamp.toIso8601String(),
+      'rawData': instance.rawData,
+      'content': instance.content,
+    };
+
 TextResponse _$TextResponseFromJson(Map<String, dynamic> json) => TextResponse(
   id: json['id'] as String,
   timestamp: DateTime.parse(json['timestamp'] as String),

--- a/packages/vide_core/lib/models/vide_global_settings.dart
+++ b/packages/vide_core/lib/models/vide_global_settings.dart
@@ -17,9 +17,15 @@ class VideGlobalSettings {
   @JsonKey(includeIfNull: false)
   final String? theme;
 
+  /// Whether to show thinking/reasoning tokens in the UI.
+  /// Defaults to false (hidden).
+  @JsonKey(defaultValue: false)
+  final bool showThinking;
+
   const VideGlobalSettings({
     this.firstRunComplete = false,
     this.theme,
+    this.showThinking = false,
   });
 
   factory VideGlobalSettings.defaults() => const VideGlobalSettings();
@@ -32,10 +38,12 @@ class VideGlobalSettings {
   VideGlobalSettings copyWith({
     bool? firstRunComplete,
     String? Function()? theme,
+    bool? showThinking,
   }) {
     return VideGlobalSettings(
       firstRunComplete: firstRunComplete ?? this.firstRunComplete,
       theme: theme != null ? theme() : this.theme,
+      showThinking: showThinking ?? this.showThinking,
     );
   }
 }

--- a/packages/vide_core/lib/models/vide_global_settings.g.dart
+++ b/packages/vide_core/lib/models/vide_global_settings.g.dart
@@ -10,10 +10,12 @@ VideGlobalSettings _$VideGlobalSettingsFromJson(Map<String, dynamic> json) =>
     VideGlobalSettings(
       firstRunComplete: json['firstRunComplete'] as bool? ?? false,
       theme: json['theme'] as String?,
+      showThinking: json['showThinking'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$VideGlobalSettingsToJson(VideGlobalSettings instance) =>
     <String, dynamic>{
       'firstRunComplete': instance.firstRunComplete,
       if (instance.theme case final value?) 'theme': value,
+      'showThinking': instance.showThinking,
     };

--- a/packages/vide_core/lib/services/vide_config_manager.dart
+++ b/packages/vide_core/lib/services/vide_config_manager.dart
@@ -149,6 +149,17 @@ class VideConfigManager {
     final settings = readGlobalSettings();
     writeGlobalSettings(settings.copyWith(theme: () => themeName));
   }
+
+  /// Get whether to show thinking tokens in the UI.
+  bool getShowThinking() {
+    return readGlobalSettings().showThinking;
+  }
+
+  /// Set whether to show thinking tokens in the UI.
+  void setShowThinking(bool show) {
+    final settings = readGlobalSettings();
+    writeGlobalSettings(settings.copyWith(showThinking: show));
+  }
 }
 
 /// Riverpod provider for VideConfigManager


### PR DESCRIPTION
Add keyboard shortcut (Ctrl+O) to toggle visibility of thinking/reasoning tokens from Claude's extended thinking feature.

Changes:
- Add ThinkingResponse class to parse thinking content blocks from API
- Update conversation loader and response processor to handle thinking
- Add showThinking setting persisted in ~/.vide/settings.json
- Add showThinkingProvider for state management
- Add Ctrl+O handler with visual feedback message
- Conditionally render thinking content in message display