### PR TITLE
feat: add --flutter-mcp flag to host Flutter MCP server

### DIFF
--- a/lib/cli/vide_command_runner.dart
+++ b/lib/cli/vide_command_runner.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:flutter_runtime_mcp/flutter_runtime_mcp.dart';
 import 'package:vide_cli/cli/connect_command.dart';
 import 'package:vide_cli/cli/daemon_command.dart';
 import 'package:vide_cli/cli/session_server_command.dart';
@@ -32,7 +33,12 @@ class VideCommandRunner extends CommandRunner<void> {
         negatable: false,
         help: 'Force local session mode (ignore daemon setting)',
       )
-      ..addFlag('daemon', negatable: false, help: 'Force daemon session mode');
+      ..addFlag('daemon', negatable: false, help: 'Force daemon session mode')
+      ..addFlag(
+        'flutter-mcp',
+        negatable: false,
+        help: 'Run as a standalone Flutter MCP server (stdio mode)',
+      );
 
     addCommand(DaemonCommand());
     addCommand(ConnectCommand());
@@ -44,6 +50,7 @@ class VideCommandRunner extends CommandRunner<void> {
 
 EXAMPLES:
     vide                                   Launch interactive TUI
+    vide --flutter-mcp                     Run Flutter MCP server (stdio)
     vide daemon start                      Start daemon on port 8080
     vide daemon start --port 9000          Start daemon on port 9000
     vide daemon start --detach             Start daemon in background
@@ -68,6 +75,11 @@ SAFETY:
   Future<void> runCommand(ArgResults topLevelResults) async {
     if (topLevelResults['version'] as bool) {
       print('vide $videVersion');
+      return;
+    }
+
+    if (topLevelResults['flutter-mcp'] as bool) {
+      await FlutterRuntimeServer().startStdio();
       return;
     }
 

--- a/packages/claude_sdk/lib/src/mcp/server/mcp_server_base.dart
+++ b/packages/claude_sdk/lib/src/mcp/server/mcp_server_base.dart
@@ -106,6 +106,24 @@ abstract class McpServerBase {
     }
   }
 
+  /// Start the server in stdio mode (for standalone MCP hosting).
+  ///
+  /// Unlike [start], this uses stdin/stdout for communication instead of HTTP.
+  /// The returned future completes when the transport is closed.
+  Future<void> startStdio() async {
+    _mcpServer = McpServer(
+      Implementation(name: name, version: version),
+      options: ServerOptions(
+        capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+      ),
+    );
+
+    registerTools(_mcpServer!);
+
+    final transport = StdioServerTransport();
+    await _mcpServer!.connect(transport);
+  }
+
   /// Stop the server
   Future<void> stop() async {
     await onStop();

--- a/packages/flutter_runtime_mcp/README.md
+++ b/packages/flutter_runtime_mcp/README.md
@@ -24,9 +24,49 @@ dependencies:
     path: ../packages/flutter_runtime_mcp
 ```
 
-## Usage
+## Standalone Usage
 
-### Starting the Server
+The easiest way to use the Flutter MCP independently is via vide:
+
+```bash
+vide --flutter-mcp
+```
+
+This starts the Flutter MCP server in stdio mode, ready for any MCP client.
+
+### Claude Code
+
+Add to `.claude/settings.local.json`:
+
+```json
+{
+  "mcpServers": {
+    "flutter-runtime": {
+      "command": "vide",
+      "args": ["--flutter-mcp"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "flutter-runtime": {
+      "command": "vide",
+      "args": ["--flutter-mcp"]
+    }
+  }
+}
+```
+
+## Programmatic Usage
+
+### Starting the Server (HTTP)
 
 ```dart
 import 'package:flutter_runtime_mcp/flutter_runtime_mcp.dart';
@@ -36,6 +76,16 @@ void main() async {
   await server.start(8081);
 
   print('Server running at: ${server.toClaudeConfig()}');
+}
+```
+
+### Starting the Server (stdio)
+
+```dart
+import 'package:flutter_runtime_mcp/flutter_runtime_mcp.dart';
+
+void main() async {
+  await FlutterRuntimeServer().startStdio();
 }
 ```
 

--- a/packages/flutter_runtime_mcp/bin/main.dart
+++ b/packages/flutter_runtime_mcp/bin/main.dart
@@ -1,18 +1,5 @@
 import 'package:flutter_runtime_mcp/flutter_runtime_mcp.dart';
-import 'package:mcp_dart/mcp_dart.dart';
 
 void main() async {
-  final flutterRuntime = FlutterRuntimeServer();
-
-  final mcpServer = McpServer(
-    Implementation(name: FlutterRuntimeServer.serverName, version: '1.0.0'),
-    options: ServerOptions(
-      capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
-    ),
-  );
-
-  flutterRuntime.registerTools(mcpServer);
-
-  final transport = StdioServerTransport();
-  await mcpServer.connect(transport);
+  await FlutterRuntimeServer().startStdio();
 }


### PR DESCRIPTION
## Summary
- Adds `vide --flutter-mcp` flag that runs the Flutter MCP server in stdio mode
- Adds `startStdio()` method to `McpServerBase` so any MCP server can be hosted via stdio
- Simplifies standalone `flutter_runtime_mcp` entry point to use the shared method

## Usage

```bash
vide --flutter-mcp
```

Claude Desktop / Claude Code config:
```json
{
  "mcpServers": {
    "flutter-runtime": {
      "command": "vide",
      "args": ["--flutter-mcp"]
    }
  }
}
```

## Test plan
- [ ] Run `vide --flutter-mcp` and verify it starts in stdio mode
- [ ] Verify `vide --help` shows the new flag
- [ ] Verify `dart analyze` passes